### PR TITLE
fix: deploy contract on the existing contract by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "npm run build:contract && npm run build:web",
     "build:contract": "near-sdk-js build src/index.ts build/contract.wasm",
     "build:web": "parcel build frontend/index.html --public-url ./",
-    "deploy": "npm run build:contract && rm -rf neardev && near dev-deploy build/contract.wasm && export $(cat ./neardev/dev-account.env) && echo $CONTRACT_NAME && near call $CONTRACT_NAME init --accountId $CONTRACT_NAME",
+    "deploy": "npm run build:contract && near dev-deploy build/contract.wasm && export $(cat ./neardev/dev-account.env) && echo $CONTRACT_NAME && near call $CONTRACT_NAME init --accountId $CONTRACT_NAME",
     "start": "npm run deploy && echo The app is starting! && export $(cat ./neardev/dev-account.env) && echo $CONTRACT_NAME && parcel frontend/index.html --open",
     "dev": "npm run deploy && nodemon --watch contract -e ts --exec \"npm run start\"",
     "test": "yarn build:contract && ava --verbose"


### PR DESCRIPTION
Instead of removing the `neardev` folder and creating a new account after making change to the source code, deploying to the existing contract account if possible. 
